### PR TITLE
feat: impl waitForTxToMine in web3 util

### DIFF
--- a/demo-web3.js
+++ b/demo-web3.js
@@ -7,6 +7,10 @@ async function demoWeb3Util() {
     const chainId = await web3.eth.net.getId();
     const mainAccount = await web3Util.getMainAccount();
     console.log({ chainId, mainAccount });
+
+    const txReceipt = await web3Util.waitForTxToMine(
+      '0xb2bbbae809cb723ae5da362ae8bfb34dfc5e064c70f59113fe74b6bcfe7859f3');
+    console.log(txReceipt);
   } catch (ex) {
     console.error(ex);
   }


### PR DESCRIPTION
## What

- impl `waitForTxToMine(txHash)` in web3 util
- refactor to move `waitSeconds` into web3 util

## Why

- needed to properly wait for some rns.js methods to complete,
  as some return a transaction hash, without waiting for the transaction to complete.
